### PR TITLE
Immediately query attribution, add integration attribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-osx_image: xcode8
+osx_image: xcode9.3
 language: objective-c
 script:
-- sudo gem install cocoapods -v 1.1.0.rc.2
-- pod repo update > /dev/null
-- pod lib lint --use-libraries
+- sudo gem install cocoapods -v 1.5.0
+- travis_retry pod repo update > /dev/null
+- pod lib lint --use-libraries --allow-warnings || pod lib lint --allow-warnings

--- a/mParticle-Button/MPKitButton.m
+++ b/mParticle-Button/MPKitButton.m
@@ -32,6 +32,7 @@ NSString * const BTNDeferredDeepLinkURLKey = @"BTNDeferredDeepLinkURLKey";
 
 NSString * const MPKitButtonErrorDomain = @"com.mparticle.kits.button";
 NSString * const MPKitButtonErrorMessageKey = @"mParticle-Button Error";
+NSString * const MPKitButtonIntegrationAttribution = @"com.usebutton.source_token";
 
 
 #pragma mark - MPIButton
@@ -57,6 +58,8 @@ NSString * const MPKitButtonErrorMessageKey = @"mParticle-Button Error";
 
 - (void)setReferrerToken:(NSString *)buttonReferrerToken {
     if (buttonReferrerToken) {
+        NSDictionary<NSString *, NSString *> *integrationAttributes = @{MPKitButtonIntegrationAttribution:buttonReferrerToken};
+        [[MParticle sharedInstance] setIntegrationAttributes:integrationAttributes forKit:[[self class] kitCode]];
         [self.userDefaults setObject:buttonReferrerToken forKey:BTNReferrerTokenDefaultsKey];
     }
     else {
@@ -133,6 +136,7 @@ NSString * const MPKitButtonErrorMessageKey = @"mParticle-Button Error";
     });
 
     execStatus = [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode] returnCode:MPKitReturnCodeSuccess];
+    [self checkForAttribution];
     return execStatus;
 }
 


### PR DESCRIPTION
This PR makes two updates:

1. Immediately request attribution on kit init. This is now necessary since we no longer have the old check for deep link API, which normally would have kicked this off.

2. Set the btn token as an integration attribute to match the Android kit, which is a long time coming.