### PR TITLE
Migrate integration to Button Merchant Library

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,2 @@
 github "mparticle/mparticle-apple-sdk" ~> 7.10.0
+github "button/button-merchant-ios" ~> 1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "button/button-merchant-ios" "1.0.1"
-github "mparticle/mparticle-apple-sdk" "7.5.7"
+github "mparticle/mparticle-apple-sdk" "7.7.3"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "button/button-merchant-ios" "1.0.1"
-github "mparticle/mparticle-apple-sdk" "7.7.3"
+github "mparticle/mparticle-apple-sdk" "7.10.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,2 @@
+github "button/button-merchant-ios" "1.0.1"
+github "mparticle/mparticle-apple-sdk" "7.5.7"

--- a/mParticle-Button.podspec
+++ b/mParticle-Button.podspec
@@ -16,4 +16,5 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "8.0"
     s.ios.source_files      = 'mParticle-Button/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 7.10.0'
+    s.ios.dependency 'ButtonMerchant', '1.0'
 end

--- a/mParticle-Button.podspec
+++ b/mParticle-Button.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "9.0"
     s.ios.source_files      = 'mParticle-Button/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 7.10.0'
-    s.ios.dependency 'ButtonMerchant', ~> '1.0'
+    s.ios.dependency 'ButtonMerchant', '~> 1'
 end

--- a/mParticle-Button.podspec
+++ b/mParticle-Button.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "8.0"
     s.ios.source_files      = 'mParticle-Button/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 7.10.0'
-    s.ios.dependency 'ButtonMerchant', '1.0'
+    s.ios.dependency 'ButtonMerchant', ~> '1.0'
 end

--- a/mParticle-Button.podspec
+++ b/mParticle-Button.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
     s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-button.git", :tag => s.version.to_s }
     s.social_media_url = "https://twitter.com/mparticle"
 
-    s.ios.deployment_target = "8.0"
+    s.ios.deployment_target = "9.0"
     s.ios.source_files      = 'mParticle-Button/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 7.10.0'
     s.ios.dependency 'ButtonMerchant', ~> '1.0'

--- a/mParticle-Button.xcodeproj/project.pbxproj
+++ b/mParticle-Button.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 				TargetAttributes = {
 					DB0773D51DB916610031F3E3 = {
 						CreatedOnToolsVersion = 8.0;
+						LastSwiftMigration = 0940;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -266,6 +267,7 @@
 		DB0773DF1DB916610031F3E3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -282,12 +284,15 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Button";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
 		DB0773E01DB916610031F3E3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -304,6 +309,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Button";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/mParticle-Button.xcodeproj/project.pbxproj
+++ b/mParticle-Button.xcodeproj/project.pbxproj
@@ -181,7 +181,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0940;
-				LastUpgradeCheck = 0940;
+				LastUpgradeCheck = 1010;
 				ORGANIZATIONNAME = mParticle;
 				TargetAttributes = {
 					DB0773D51DB916610031F3E3 = {

--- a/mParticle-Button.xcodeproj/project.pbxproj
+++ b/mParticle-Button.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		DB0773E41DB916B80031F3E3 /* MPKitButton.m in Sources */ = {isa = PBXBuildFile; fileRef = DB0773E21DB916B80031F3E3 /* MPKitButton.m */; };
 		DE811925214C4CF900AAC951 /* mParticle_Button.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB0773D61DB916610031F3E3 /* mParticle_Button.framework */; };
 		DE81192F214C4F5500AAC951 /* mParticle-ButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE81192D214C4F5400AAC951 /* mParticle-ButtonTests.swift */; };
+		DEAA37222180E11800915875 /* MPKitButton+ButtonTests.m in Sources */ = {isa = PBXBuildFile; fileRef = DEAA37212180E11800915875 /* MPKitButton+ButtonTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -34,6 +35,9 @@
 		DE811920214C4CF900AAC951 /* mParticle-ButtonTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "mParticle-ButtonTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE81192D214C4F5400AAC951 /* mParticle-ButtonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "mParticle-ButtonTests.swift"; sourceTree = "<group>"; };
 		DE81192E214C4F5400AAC951 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DEAA371F2180E11700915875 /* mParticle-ButtonTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "mParticle-ButtonTests-Bridging-Header.h"; sourceTree = "<group>"; };
+		DEAA37202180E11800915875 /* MPKitButton+ButtonTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MPKitButton+ButtonTests.h"; sourceTree = "<group>"; };
+		DEAA37212180E11800915875 /* MPKitButton+ButtonTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "MPKitButton+ButtonTests.m"; sourceTree = "<group>"; };
 		DEEEE6A3214C57BF006B5C06 /* ButtonMerchant.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ButtonMerchant.framework; path = Carthage/Build/iOS/ButtonMerchant.framework; sourceTree = "<group>"; };
 		DEEEE6A4214C57CA006B5C06 /* mParticle_Apple_SDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = mParticle_Apple_SDK.framework; path = Carthage/Build/iOS/mParticle_Apple_SDK.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -100,10 +104,21 @@
 		DE81192C214C4F5400AAC951 /* mParticle-ButtonTests */ = {
 			isa = PBXGroup;
 			children = (
+				DEAA37232180E11F00915875 /* Helpers */,
 				DE81192D214C4F5400AAC951 /* mParticle-ButtonTests.swift */,
 				DE81192E214C4F5400AAC951 /* Info.plist */,
 			);
 			path = "mParticle-ButtonTests";
+			sourceTree = "<group>";
+		};
+		DEAA37232180E11F00915875 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				DEAA371F2180E11700915875 /* mParticle-ButtonTests-Bridging-Header.h */,
+				DEAA37202180E11800915875 /* MPKitButton+ButtonTests.h */,
+				DEAA37212180E11800915875 /* MPKitButton+ButtonTests.m */,
+			);
+			path = Helpers;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -178,6 +193,7 @@
 					DE81191F214C4CF900AAC951 = {
 						CreatedOnToolsVersion = 9.4.1;
 						DevelopmentTeam = 39F27QYP2C;
+						LastSwiftMigration = 0940;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -266,6 +282,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DE81192F214C4F5500AAC951 /* mParticle-ButtonTests.swift in Sources */,
+				DEAA37222180E11800915875 /* MPKitButton+ButtonTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -411,7 +428,7 @@
 				);
 				INFOPLIST_FILE = "mParticle-Button/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Button";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -439,7 +456,7 @@
 				);
 				INFOPLIST_FILE = "mParticle-Button/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Button";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -454,6 +471,7 @@
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -465,12 +483,13 @@
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "mParticle-ButtonTests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.usebutton.mParticle-ButtonTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OBJC_BRIDGING_HEADER = "mParticle-ButtonTests/Helpers/mParticle-ButtonTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -482,6 +501,7 @@
 			buildSettings = {
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -493,11 +513,12 @@
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "mParticle-ButtonTests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.usebutton.mParticle-ButtonTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_OBJC_BRIDGING_HEADER = "mParticle-ButtonTests/Helpers/mParticle-ButtonTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/mParticle-Button.xcodeproj/project.pbxproj
+++ b/mParticle-Button.xcodeproj/project.pbxproj
@@ -10,8 +10,19 @@
 		DB0773DB1DB916610031F3E3 /* mParticle_Button.h in Headers */ = {isa = PBXBuildFile; fileRef = DB0773D91DB916610031F3E3 /* mParticle_Button.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB0773E31DB916B80031F3E3 /* MPKitButton.h in Headers */ = {isa = PBXBuildFile; fileRef = DB0773E11DB916B80031F3E3 /* MPKitButton.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DB0773E41DB916B80031F3E3 /* MPKitButton.m in Sources */ = {isa = PBXBuildFile; fileRef = DB0773E21DB916B80031F3E3 /* MPKitButton.m */; };
-		DB0773E61DB917DB0031F3E3 /* mParticle_Apple_SDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB0773E51DB917DB0031F3E3 /* mParticle_Apple_SDK.framework */; };
+		DE811925214C4CF900AAC951 /* mParticle_Button.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB0773D61DB916610031F3E3 /* mParticle_Button.framework */; };
+		DE81192F214C4F5500AAC951 /* mParticle-ButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE81192D214C4F5400AAC951 /* mParticle-ButtonTests.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		DE811926214C4CF900AAC951 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DB0773CD1DB916610031F3E3 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DB0773D51DB916610031F3E3;
+			remoteInfo = "mParticle-Button";
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		DB0773D61DB916610031F3E3 /* mParticle_Button.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = mParticle_Button.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -19,7 +30,12 @@
 		DB0773DA1DB916610031F3E3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DB0773E11DB916B80031F3E3 /* MPKitButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MPKitButton.h; sourceTree = "<group>"; };
 		DB0773E21DB916B80031F3E3 /* MPKitButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MPKitButton.m; sourceTree = "<group>"; };
-		DB0773E51DB917DB0031F3E3 /* mParticle_Apple_SDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = mParticle_Apple_SDK.framework; path = Carthage/Build/iOS/mParticle_Apple_SDK.framework; sourceTree = "<group>"; };
+		DE0F93D12149694E00E0FF7F /* mParticle-Button.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = "mParticle-Button.podspec"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		DE811920214C4CF900AAC951 /* mParticle-ButtonTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "mParticle-ButtonTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		DE81192D214C4F5400AAC951 /* mParticle-ButtonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "mParticle-ButtonTests.swift"; sourceTree = "<group>"; };
+		DE81192E214C4F5400AAC951 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DEEEE6A3214C57BF006B5C06 /* ButtonMerchant.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ButtonMerchant.framework; path = Carthage/Build/iOS/ButtonMerchant.framework; sourceTree = "<group>"; };
+		DEEEE6A4214C57CA006B5C06 /* mParticle_Apple_SDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = mParticle_Apple_SDK.framework; path = Carthage/Build/iOS/mParticle_Apple_SDK.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -27,19 +43,37 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DB0773E61DB917DB0031F3E3 /* mParticle_Apple_SDK.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DE81191D214C4CF900AAC951 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DE811925214C4CF900AAC951 /* mParticle_Button.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		9E95DB5F21484465006F257C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				DEEEE6A4214C57CA006B5C06 /* mParticle_Apple_SDK.framework */,
+				DEEEE6A3214C57BF006B5C06 /* ButtonMerchant.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		DB0773CC1DB916610031F3E3 = {
 			isa = PBXGroup;
 			children = (
-				DB0773E51DB917DB0031F3E3 /* mParticle_Apple_SDK.framework */,
+				DE0F93D12149694E00E0FF7F /* mParticle-Button.podspec */,
 				DB0773D81DB916610031F3E3 /* mParticle-Button */,
+				DE81192C214C4F5400AAC951 /* mParticle-ButtonTests */,
 				DB0773D71DB916610031F3E3 /* Products */,
+				9E95DB5F21484465006F257C /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -47,6 +81,7 @@
 			isa = PBXGroup;
 			children = (
 				DB0773D61DB916610031F3E3 /* mParticle_Button.framework */,
+				DE811920214C4CF900AAC951 /* mParticle-ButtonTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -60,6 +95,15 @@
 				DB0773DA1DB916610031F3E3 /* Info.plist */,
 			);
 			path = "mParticle-Button";
+			sourceTree = "<group>";
+		};
+		DE81192C214C4F5400AAC951 /* mParticle-ButtonTests */ = {
+			isa = PBXGroup;
+			children = (
+				DE81192D214C4F5400AAC951 /* mParticle-ButtonTests.swift */,
+				DE81192E214C4F5400AAC951 /* Info.plist */,
+			);
+			path = "mParticle-ButtonTests";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -84,6 +128,7 @@
 				DB0773D11DB916610031F3E3 /* Sources */,
 				DB0773D21DB916610031F3E3 /* Frameworks */,
 				DB0773D31DB916610031F3E3 /* Headers */,
+				DE0F93A621486B3900E0FF7F /* Carthage */,
 				DB0773D41DB916610031F3E3 /* Resources */,
 			);
 			buildRules = (
@@ -95,18 +140,44 @@
 			productReference = DB0773D61DB916610031F3E3 /* mParticle_Button.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		DE81191F214C4CF900AAC951 /* mParticle-ButtonTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DE811928214C4CF900AAC951 /* Build configuration list for PBXNativeTarget "mParticle-ButtonTests" */;
+			buildPhases = (
+				DE81191C214C4CF900AAC951 /* Sources */,
+				DE81191D214C4CF900AAC951 /* Frameworks */,
+				DE81191E214C4CF900AAC951 /* Resources */,
+				DE81192B214C4E9F00AAC951 /* Carthage */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DE811927214C4CF900AAC951 /* PBXTargetDependency */,
+			);
+			name = "mParticle-ButtonTests";
+			productName = "mParticle-ButtonTests";
+			productReference = DE811920214C4CF900AAC951 /* mParticle-ButtonTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		DB0773CD1DB916610031F3E3 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftUpdateCheck = 0940;
 				LastUpgradeCheck = 0940;
 				ORGANIZATIONNAME = mParticle;
 				TargetAttributes = {
 					DB0773D51DB916610031F3E3 = {
 						CreatedOnToolsVersion = 8.0;
+						DevelopmentTeam = 39F27QYP2C;
 						LastSwiftMigration = 0940;
+						ProvisioningStyle = Automatic;
+					};
+					DE81191F214C4CF900AAC951 = {
+						CreatedOnToolsVersion = 9.4.1;
+						DevelopmentTeam = 39F27QYP2C;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -124,6 +195,7 @@
 			projectRoot = "";
 			targets = (
 				DB0773D51DB916610031F3E3 /* mParticle-Button */,
+				DE81191F214C4CF900AAC951 /* mParticle-ButtonTests */,
 			);
 		};
 /* End PBXProject section */
@@ -136,7 +208,49 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DE81191E214C4CF900AAC951 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		DE0F93A621486B3900E0FF7F /* Carthage */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/iOS/ButtonMerchant.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/mParticle_Apple_SDK.framework",
+			);
+			name = Carthage;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "#/usr/local/bin/carthage copy-frameworks";
+		};
+		DE81192B214C4E9F00AAC951 /* Carthage */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Carthage/Build/iOS/ButtonMerchant.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/mParticle_Apple_SDK.framework",
+			);
+			name = Carthage;
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/local/bin/carthage copy-frameworks";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		DB0773D11DB916610031F3E3 /* Sources */ = {
@@ -147,7 +261,23 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DE81191C214C4CF900AAC951 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DE81192F214C4F5500AAC951 /* mParticle-ButtonTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		DE811927214C4CF900AAC951 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DB0773D51DB916610031F3E3 /* mParticle-Button */;
+			targetProxy = DE811926214C4CF900AAC951 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		DB0773DC1DB916610031F3E3 /* Debug */ = {
@@ -268,8 +398,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 39F27QYP2C;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -283,6 +415,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Button";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
@@ -293,8 +426,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = 39F27QYP2C;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -308,8 +443,64 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mparticle.mParticle-Button";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 3.0;
+			};
+			name = Release;
+		};
+		DE811929214C4CF900AAC951 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 39F27QYP2C;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SRCROOT)/Carthage/Build/iOS/**",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "mParticle-ButtonTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.usebutton.mParticle-ButtonTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		DE81192A214C4CF900AAC951 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = 39F27QYP2C;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SRCROOT)/Carthage/Build/iOS/**",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "mParticle-ButtonTests/Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.usebutton.mParticle-ButtonTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -330,6 +521,15 @@
 			buildConfigurations = (
 				DB0773DF1DB916610031F3E3 /* Debug */,
 				DB0773E01DB916610031F3E3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DE811928214C4CF900AAC951 /* Build configuration list for PBXNativeTarget "mParticle-ButtonTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DE811929214C4CF900AAC951 /* Debug */,
+				DE81192A214C4CF900AAC951 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/mParticle-Button.xcodeproj/xcshareddata/xcschemes/mParticle-Button.xcscheme
+++ b/mParticle-Button.xcodeproj/xcshareddata/xcschemes/mParticle-Button.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1010"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -42,6 +42,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DE81191F214C4CF900AAC951"
+               BuildableName = "mParticle-ButtonTests.xctest"
+               BlueprintName = "mParticle-ButtonTests"
+               ReferencedContainer = "container:mParticle-Button.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/mParticle-Button.xcodeproj/xcshareddata/xcschemes/mParticle-Button.xcscheme
+++ b/mParticle-Button.xcodeproj/xcshareddata/xcschemes/mParticle-Button.xcscheme
@@ -28,7 +28,7 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DE0F93972148654000E0FF7F"
+               BlueprintIdentifier = "DE81191F214C4CF900AAC951"
                BuildableName = "mParticle-ButtonTests.xctest"
                BlueprintName = "mParticle-ButtonTests"
                ReferencedContainer = "container:mParticle-Button.xcodeproj">

--- a/mParticle-Button.xcodeproj/xcshareddata/xcschemes/mParticle-ButtonTests.xcscheme
+++ b/mParticle-Button.xcodeproj/xcshareddata/xcschemes/mParticle-ButtonTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1010"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/mParticle-Button.xcodeproj/xcshareddata/xcschemes/mParticle-ButtonTests.xcscheme
+++ b/mParticle-Button.xcodeproj/xcshareddata/xcschemes/mParticle-ButtonTests.xcscheme
@@ -9,26 +9,12 @@
          <BuildActionEntry
             buildForTesting = "YES"
             buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DB0773D51DB916610031F3E3"
-               BuildableName = "mParticle_Button.framework"
-               BlueprintName = "mParticle-Button"
-               ReferencedContainer = "container:mParticle-Button.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "DE0F93972148654000E0FF7F"
+               BlueprintIdentifier = "DE81191F214C4CF900AAC951"
                BuildableName = "mParticle-ButtonTests.xctest"
                BlueprintName = "mParticle-ButtonTests"
                ReferencedContainer = "container:mParticle-Button.xcodeproj">
@@ -38,17 +24,27 @@
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DE81191F214C4CF900AAC951"
+               BuildableName = "mParticle-ButtonTests.xctest"
+               BlueprintName = "mParticle-ButtonTests"
+               ReferencedContainer = "container:mParticle-Button.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DB0773D51DB916610031F3E3"
-            BuildableName = "mParticle_Button.framework"
-            BlueprintName = "mParticle-Button"
+            BlueprintIdentifier = "DE81191F214C4CF900AAC951"
+            BuildableName = "mParticle-ButtonTests.xctest"
+            BlueprintName = "mParticle-ButtonTests"
             ReferencedContainer = "container:mParticle-Button.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -68,9 +64,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DB0773D51DB916610031F3E3"
-            BuildableName = "mParticle_Button.framework"
-            BlueprintName = "mParticle-Button"
+            BlueprintIdentifier = "DE81191F214C4CF900AAC951"
+            BuildableName = "mParticle-ButtonTests.xctest"
+            BlueprintName = "mParticle-ButtonTests"
             ReferencedContainer = "container:mParticle-Button.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -86,9 +82,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DB0773D51DB916610031F3E3"
-            BuildableName = "mParticle_Button.framework"
-            BlueprintName = "mParticle-Button"
+            BlueprintIdentifier = "DE81191F214C4CF900AAC951"
+            BuildableName = "mParticle-ButtonTests.xctest"
+            BlueprintName = "mParticle-ButtonTests"
             ReferencedContainer = "container:mParticle-Button.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/mParticle-Button/MPKitButton.h
+++ b/mParticle-Button/MPKitButton.h
@@ -15,13 +15,13 @@ extern NSString * _Nonnull const MPKitButtonErrorMessageKey;
 extern NSString * _Nonnull const MPKitButtonAttributionResultKey;
 
 /// A key into the linkInfo passed to the onAttributionComplete handler.
-extern NSString * _Nonnull const BTNDeferredDeepLinkURLKey;
+extern NSString * _Nonnull const BTNPostInstallURLKey;
 
 #pragma mark - MPIButton
 @interface MPIButton : NSObject
 
 /// Returns the Button referrer token if present (i.e. btn_ref).
-@property (nonatomic, copy, readonly, nullable) NSString *referrerToken;
+@property (nonatomic, copy, readonly, nullable) NSString *attributionToken;
 
 @end
 

--- a/mParticle-Button/MPKitButton.m
+++ b/mParticle-Button/MPKitButton.m
@@ -2,6 +2,7 @@
 #include <sys/types.h>
 #include <sys/sysctl.h>
 
+@import ButtonMerchant;
 @import AdSupport.ASIdentifierManager;
 
 static NSString * const BTNMPKitVersion = @"1.0.0";
@@ -10,7 +11,7 @@ static NSString * const BTNReferrerTokenDefaultsKey   = @"com.usebutton.referrer
 static NSString * const BTNLinkFetchStatusDefaultsKey = @"com.usebutton.link.fetched";
 
 NSString * const MPKitButtonAttributionResultKey = @"mParticle-Button Attribution Result";
-NSString * const BTNDeferredDeepLinkURLKey = @"BTNDeferredDeepLinkURLKey";
+NSString * const BTNPostInstallURLKey = @"BTNPostInstallURLKey";
 
 NSString * const MPKitButtonErrorDomain = @"com.mparticle.kits.button";
 NSString * const MPKitButtonErrorMessageKey = @"mParticle-Button Error";
@@ -18,55 +19,30 @@ NSString * const MPKitButtonIntegrationAttribution = @"com.usebutton.source_toke
 
 
 #pragma mark - MPIButton
-@interface MPIButton()
-
-@property (nonatomic, copy, nullable) NSString *referrerToken;
-@property (nonatomic, strong) NSUserDefaults *userDefaults;
-
-@end
 
 @implementation MPIButton
 
 - (instancetype)init {
     self = [super init];
-    _userDefaults = [NSUserDefaults standardUserDefaults];
     return self;
 }
 
-- (NSString *)referrerToken {
-    return [self.userDefaults objectForKey:BTNReferrerTokenDefaultsKey];
+
+- (NSString *)attributionToken {
+    return ButtonMerchant.attributionToken;
 }
 
-
-- (void)setReferrerToken:(NSString *)buttonReferrerToken {
-    if (buttonReferrerToken) {
-        NSDictionary<NSString *, NSString *> *integrationAttributes = @{MPKitButtonIntegrationAttribution:buttonReferrerToken};
-        [[MParticle sharedInstance] setIntegrationAttributes:integrationAttributes forKit:[[MPKitButton class] kitCode]];
-        [self.userDefaults setObject:buttonReferrerToken forKey:BTNReferrerTokenDefaultsKey];
-    }
-    else {
-        [self.userDefaults removeObjectForKey:BTNReferrerTokenDefaultsKey];
-    }
-}
 
 @end
 
 
 #pragma mark - MPKitButton
+
 @interface MPKitButton ()
 
 @property (nonatomic, strong, nonnull) MPIButton *button;
 @property (nonatomic, copy)   NSString *applicationId;
 @property (nonatomic, strong) NSURLSession *session;
-
-// Dependencies
-@property (nonatomic, strong) NSFileManager  *fileManager;
-@property (nonatomic, strong) NSUserDefaults *userDefaults;
-@property (nonatomic, strong) UIDevice *device;
-@property (nonatomic, strong) UIScreen *screen;
-@property (nonatomic, strong) NSLocale *locale;
-@property (nonatomic, strong) NSBundle *mainBundle;
-@property (nonatomic, strong) ASIdentifierManager *IFAManager;
 
 @end
 
@@ -87,34 +63,23 @@ NSString * const MPKitButtonIntegrationAttribution = @"com.usebutton.source_toke
 }
 
 
-#pragma mark MPKitInstanceProtocol methods
+#pragma mark - MPKitInstanceProtocol methods
 
 - (MPKitExecStatus *)didFinishLaunchingWithConfiguration:(NSDictionary *)configuration {
     MPKitExecStatus *execStatus = nil;
-
+    _button = [[MPIButton alloc] init];
     _applicationId = [configuration[@"application_id"] copy];
     if (!_applicationId) {
         execStatus = [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode] returnCode:MPKitReturnCodeRequirementsNotMet];
         return execStatus;
     }
 
-    _fileManager  = [NSFileManager defaultManager];
-    _userDefaults = [NSUserDefaults standardUserDefaults];
-    _device       = [UIDevice currentDevice];
-    _screen       = [UIScreen mainScreen];
-    _locale       = [NSLocale currentLocale];
-    _mainBundle   = [NSBundle mainBundle];
-    _IFAManager   = [ASIdentifierManager sharedManager];
+    [ButtonMerchant configureWithApplicationId:_applicationId];
 
     _configuration = configuration;
     _started       = YES;
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        NSDictionary *userInfo = @{ mParticleKitInstanceKey: [[self class] kitCode] };
-
-        [[NSNotificationCenter defaultCenter] postNotificationName:mParticleKitDidBecomeActiveNotification
-                                                            object:nil
-                                                          userInfo:userInfo];
         [self checkForAttribution];
     });
 
@@ -123,211 +88,57 @@ NSString * const MPKitButtonIntegrationAttribution = @"com.usebutton.source_toke
     return execStatus;
 }
 
+
 - (id)providerKitInstance {
     return [self started] ? self.button : nil;
 }
 
-- (NSError *)errorWithMessage:(NSString *)message {
-    NSError *error = [NSError errorWithDomain:MPKitButtonErrorDomain code:0 userInfo:@{MPKitButtonErrorMessageKey: message}];
-    return error;
-}
-
-- (void)checkForAttribution {
-    BOOL isNewInstall = [self isNewInstall];
-    BOOL didFetchLink = [self.userDefaults boolForKey:BTNLinkFetchStatusDefaultsKey];
-
-    if (!isNewInstall || didFetchLink || !self.applicationId.length) {
-        NSError *error = [self errorWithMessage:@"Requirements not met"];
-        [_kitApi onAttributionCompleteWithResult:nil error:error];
-        return;
-    }
-
-    [self.userDefaults setBool:YES forKey:BTNLinkFetchStatusDefaultsKey];
-
-    if (!self.session) {
-        self.session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
-    }
-
-    NSURL *url = [NSURL URLWithString:@"https://api.usebutton.com/v1/web/deferred-deeplink"];
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
-    request.HTTPMethod = @"POST";
-    [request addValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
-    [request addValue:@"application/json" forHTTPHeaderField:@"Accept"];
-    [request addValue:[self userAgentString] forHTTPHeaderField:@"User-Agent"];
-
-    NSMutableDictionary *signals = [NSMutableDictionary dictionary];
-    signals[@"source"]     = @"mparticle";
-    signals[@"os"]         = @"ios";
-    signals[@"os_version"] = self.device.systemVersion ?: @"";
-    signals[@"device"]     = self.device.model ?: @"";
-    signals[@"country"]    = [self.locale objectForKey:NSLocaleCountryCode] ?: @"";
-    signals[@"language"]   = [self preferredLanguage] ?: @"";
-    signals[@"screen"]     = [NSString stringWithFormat:@"%@x%@",
-                              @(self.screen.bounds.size.width * self.screen.scale),
-                              @(self.screen.bounds.size.height * self.screen.scale)];
-
-    NSMutableDictionary *params = [NSMutableDictionary dictionary];
-    params[@"application_id"] = self.applicationId ?: @"";
-    params[@"ifa"]            = self.IFAManager.advertisingIdentifier.UUIDString ?: @"";
-    params[@"signals"]        = signals;
-
-    NSError *error = nil;
-    NSData *requestData = nil;
-
-    @try {
-        requestData = [NSJSONSerialization dataWithJSONObject:[params copy] options:0 error:&error];
-    } @catch (NSException *exception) {
-    }
-
-    if (!requestData && error) {
-        NSError *error = [self errorWithMessage:[NSString stringWithFormat:@"JSON serialization of request data failed: %@", error]];
-        [_kitApi onAttributionCompleteWithResult:nil error:error];
-        return;
-    }
-
-    request.HTTPBody = requestData;
-    [[self.session dataTaskWithRequest:request completionHandler:
-      ^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
-
-          NSDictionary *linkInfo = nil;
-          if (!error) {
-              id responseObject    = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
-              BOOL isValidResponse = [responseObject isKindOfClass:[NSDictionary class]] &&
-                                     [responseObject[@"meta"] isKindOfClass:[NSDictionary class]] &&
-                                     [responseObject[@"meta"][@"status"] isEqualToString:@"ok"] &&
-                                     [responseObject[@"object"] isKindOfClass:[NSDictionary class]];
-
-              if (isValidResponse) {
-                  NSDictionary *object = responseObject[@"object"];
-                  if ([object[@"attribution"] isKindOfClass:[NSDictionary class]]) {
-                      NSString *referrer = object[@"attribution"][@"btn_ref"];
-
-                      if (referrer.length) {
-                          self.button.referrerToken = referrer;
-                      }
-                  }
-
-                  if ([object[@"action"] length]) {
-                      linkInfo = @{ BTNDeferredDeepLinkURLKey: object[@"action"], MPKitButtonAttributionResultKey: object[@"action"] };
-
-                      MPAttributionResult *attributionResult = [[MPAttributionResult alloc] init];
-                      attributionResult.linkInfo = linkInfo;
-
-                      [self->_kitApi onAttributionCompleteWithResult:attributionResult error:nil];
-                  }
-                  else {
-                      NSError *attributionError = [self errorWithMessage:@"Response dictionary value for key 'action' was empty or missing"];
-                      [self->_kitApi onAttributionCompleteWithResult:nil error:attributionError];
-                      return;
-                  }
-              } else {
-                  NSError *attributionError = [self errorWithMessage:@"Not a valid response"];
-                  [self->_kitApi onAttributionCompleteWithResult:nil error:attributionError];
-                  return;
-              }
-
-          } else {
-              NSError *attributionError = [self errorWithMessage:[NSString stringWithFormat:@"Data task failed with error: %@", error]];
-              [self->_kitApi onAttributionCompleteWithResult:nil error:attributionError];
-              return;
-          }
-
-    }] resume];
-}
-
 
 - (nonnull MPKitExecStatus *)openURL:(nonnull NSURL *)url options:(nullable NSDictionary<NSString *, id> *)options {
-    [self applyAttributionFromURL:url];
+    [ButtonMerchant trackIncomingURL:url];
     return [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode]
                                          returnCode:MPKitReturnCodeSuccess];
 }
 
 
 - (nonnull MPKitExecStatus *)openURL:(nonnull NSURL *)url sourceApplication:(nullable NSString *)sourceApplication annotation:(nullable id)annotation {
-    [self applyAttributionFromURL:url];
+    [ButtonMerchant trackIncomingURL:url];
     return [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode]
                                          returnCode:MPKitReturnCodeSuccess];
 }
 
 
 - (nonnull MPKitExecStatus *)continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(void(^ _Nonnull)(NSArray * _Nullable restorableObjects))restorationHandler {
-    [self applyAttributionFromURL:userActivity.webpageURL];
+    [ButtonMerchant trackIncomingUserActivity:userActivity];
     return [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode]
                                          returnCode:MPKitReturnCodeSuccess];
 }
 
 
-#pragma mark - Button specific
+#pragma mark - Private Methods
 
-- (MPIButton *)button {
-    if (!_button) {
-        _button = [[MPIButton alloc] init];
-    }
-
-    return _button;
-}
-
-- (BOOL)isNewInstall {
-    NSString *documentsPath = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
-    NSDictionary *attributes = [self.fileManager attributesOfItemAtPath:documentsPath error:nil];
-    NSDate *twelveHoursAgo = [[NSCalendar currentCalendar] dateByAddingUnit:NSCalendarUnitHour
-                                                                      value:-12
-                                                                     toDate:[NSDate date]
-                                                                    options:0];
-
-    return [[attributes fileCreationDate] compare:twelveHoursAgo] == NSOrderedDescending;
+- (NSError *)errorWithMessage:(NSString *)message {
+    NSError *error = [NSError errorWithDomain:MPKitButtonErrorDomain code:0 userInfo:@{MPKitButtonErrorMessageKey: message}];
+    return error;
 }
 
 
-- (void)applyAttributionFromURL:(NSURL *)url {
-    Class queryItemClass = NSClassFromString(@"NSURLQueryItem");
-    if (queryItemClass) {
-        NSURLComponents *urlComponents = [NSURLComponents componentsWithString:url.absoluteString];
-
-        for (NSURLQueryItem *item in urlComponents.queryItems) {
-
-            if ([item.name isEqualToString:@"btn_ref"] && item.value.length) {
-                self.button.referrerToken = item.value;
-                break;
-            }
+- (void)checkForAttribution {
+    [ButtonMerchant handlePostInstallURL:^(NSURL * _Nullable postInstallURL, NSError * _Nullable error) {
+        if (error) {
+            NSError *attributionError = [self errorWithMessage:@"No attribution information available."];
+            [self->_kitApi onAttributionCompleteWithResult:nil error:attributionError];
+            return;
         }
-    }
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self checkForAttribution];
-    });
-
+        if (!postInstallURL) {
+            return;
+        }
+        NSDictionary *linkInfo = @{ BTNPostInstallURLKey: postInstallURL};
+        MPAttributionResult *attributionResult = [[MPAttributionResult alloc] init];
+        attributionResult.linkInfo = linkInfo;
+        [self->_kitApi onAttributionCompleteWithResult:attributionResult error:nil];
+    }];
 }
 
-
-- (NSString *)userAgentString {
-    return [NSString stringWithFormat:@"%@/%@-%@ (iOS %@; %@; %@/%@; Scale/%0.1f; %@-%@)",
-            @"com.usebutton.mparticle",
-            [MParticle sharedInstance].version,
-            BTNMPKitVersion,
-            self.device.systemVersion,
-            [self platformString],
-            self.mainBundle.infoDictionary[(__bridge NSString *)kCFBundleIdentifierKey],
-            self.mainBundle.infoDictionary[(__bridge NSString *)kCFBundleVersionKey],
-            self.screen.scale,
-            [self preferredLanguage],
-            [self.locale objectForKey:NSLocaleCountryCode]];
-}
-
-
-- (NSString *)preferredLanguage {
-    return [[[self.locale class] preferredLanguages].firstObject
-            componentsSeparatedByString:@"-"].firstObject ?: @"en";
-}
-
-
-- (NSString *)platformString {
-    size_t size;
-    sysctlbyname("hw.machine", NULL, &size, NULL, 0);
-    char *machine = malloc(size);
-    sysctlbyname("hw.machine", machine, &size, NULL, 0);
-    NSString *platform = @(machine);
-    free(machine);
-    return platform;
-}
 
 @end

--- a/mParticle-Button/MPKitButton.m
+++ b/mParticle-Button/MPKitButton.m
@@ -1,11 +1,26 @@
+//
+//  MPKitButton.m
+//
+//  Copyright 2019 Button, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
 #import "MPKitButton.h"
-#include <sys/types.h>
-#include <sys/sysctl.h>
 
 @import ButtonMerchant;
-@import AdSupport.ASIdentifierManager;
 
-static NSString * const BTNMPKitVersion = @"1.0.0";
+static NSString * const BTNMPKitVersion = @"2.0.0";
 
 static NSString * const BTNReferrerTokenDefaultsKey   = @"com.usebutton.referrer";
 static NSString * const BTNLinkFetchStatusDefaultsKey = @"com.usebutton.link.fetched";
@@ -31,7 +46,6 @@ NSString * const MPKitButtonIntegrationAttribution = @"com.usebutton.source_toke
 - (NSString *)attributionToken {
     return ButtonMerchant.attributionToken;
 }
-
 
 @end
 
@@ -125,12 +139,9 @@ NSString * const MPKitButtonIntegrationAttribution = @"com.usebutton.source_toke
 
 - (void)checkForAttribution {
     [ButtonMerchant handlePostInstallURL:^(NSURL * _Nullable postInstallURL, NSError * _Nullable error) {
-        if (error) {
+        if (error || !postInstallURL) {
             NSError *attributionError = [self errorWithMessage:@"No attribution information available."];
             [self->_kitApi onAttributionCompleteWithResult:nil error:attributionError];
-            return;
-        }
-        if (!postInstallURL) {
             return;
         }
         NSDictionary *linkInfo = @{ BTNPostInstallURLKey: postInstallURL};
@@ -139,6 +150,5 @@ NSString * const MPKitButtonIntegrationAttribution = @"com.usebutton.source_toke
         [self->_kitApi onAttributionCompleteWithResult:attributionResult error:nil];
     }];
 }
-
 
 @end

--- a/mParticle-Button/MPKitButton.m
+++ b/mParticle-Button/MPKitButton.m
@@ -54,6 +54,7 @@ NSString * const MPKitButtonIntegrationAttribution = @"com.usebutton.source_toke
 
 @interface MPKitButton ()
 
+@property (nonatomic, strong) MParticle *mParticleInstance;
 @property (nonatomic, strong, nonnull) MPIButton *button;
 @property (nonatomic, copy)   NSString *applicationId;
 @property (nonatomic, strong) NSURLSession *session;
@@ -74,6 +75,25 @@ NSString * const MPKitButtonIntegrationAttribution = @"com.usebutton.source_toke
     MPKitRegister *kitRegister = [[MPKitRegister alloc] initWithName:@"Button"
                                                            className:NSStringFromClass(self)];
     [MParticle registerExtension:kitRegister];
+}
+
+
+- (MParticle *)mParticleInstance {
+    if (!_mParticleInstance) {
+        return [MParticle sharedInstance];
+    }
+
+    return _mParticleInstance;
+}
+
+
+- (void)trackIncomingURL:(NSURL *)url {
+    [ButtonMerchant trackIncomingURL:url];
+    NSString *attributionToken = ButtonMerchant.attributionToken;
+    if (attributionToken) {
+        NSDictionary<NSString *, NSString *> *integrationAttributes = @{ MPKitButtonIntegrationAttribution: attributionToken };
+        [_mParticleInstance setIntegrationAttributes:integrationAttributes forKit:[[self class] kitCode]];
+    }
 }
 
 
@@ -109,21 +129,21 @@ NSString * const MPKitButtonIntegrationAttribution = @"com.usebutton.source_toke
 
 
 - (nonnull MPKitExecStatus *)openURL:(nonnull NSURL *)url options:(nullable NSDictionary<NSString *, id> *)options {
-    [ButtonMerchant trackIncomingURL:url];
+    [self trackIncomingURL:url];
     return [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode]
                                          returnCode:MPKitReturnCodeSuccess];
 }
 
 
 - (nonnull MPKitExecStatus *)openURL:(nonnull NSURL *)url sourceApplication:(nullable NSString *)sourceApplication annotation:(nullable id)annotation {
-    [ButtonMerchant trackIncomingURL:url];
+    [self trackIncomingURL:url];
     return [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode]
                                          returnCode:MPKitReturnCodeSuccess];
 }
 
 
 - (nonnull MPKitExecStatus *)continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(void(^ _Nonnull)(NSArray * _Nullable restorableObjects))restorationHandler {
-    [ButtonMerchant trackIncomingUserActivity:userActivity];
+    [self trackIncomingURL:userActivity.webpageURL];
     return [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode]
                                          returnCode:MPKitReturnCodeSuccess];
 }

--- a/mParticle-Button/MPKitButton.m
+++ b/mParticle-Button/MPKitButton.m
@@ -144,7 +144,7 @@ NSString * const MPKitButtonIntegrationAttribution = @"com.usebutton.source_toke
             [self->_kitApi onAttributionCompleteWithResult:nil error:attributionError];
             return;
         }
-        NSDictionary *linkInfo = @{ BTNPostInstallURLKey: postInstallURL};
+        NSDictionary *linkInfo = @{ BTNPostInstallURLKey: postInstallURL.absoluteString };
         MPAttributionResult *attributionResult = [[MPAttributionResult alloc] init];
         attributionResult.linkInfo = linkInfo;
         [self->_kitApi onAttributionCompleteWithResult:attributionResult error:nil];

--- a/mParticle-Button/mParticle_Button.h
+++ b/mParticle-Button/mParticle_Button.h
@@ -1,4 +1,5 @@
 #import <UIKit/UIKit.h>
+@import ButtonMerchant;
 
 //! Project version number for mParticle-Button.
 FOUNDATION_EXPORT double mParticle_ButtonVersionNumber;

--- a/mParticle-ButtonTests/Helpers/MPKitButton+ButtonTests.h
+++ b/mParticle-ButtonTests/Helpers/MPKitButton+ButtonTests.h
@@ -1,0 +1,7 @@
+#import "mParticle_Button.h"
+
+@interface MPKitButton (ButtonTests)
+@property (nonatomic, strong) MParticle *mParticleInstance;
+@end
+
+

--- a/mParticle-ButtonTests/Helpers/MPKitButton+ButtonTests.m
+++ b/mParticle-ButtonTests/Helpers/MPKitButton+ButtonTests.m
@@ -1,0 +1,5 @@
+#import "MPKitButton+ButtonTests.h"
+
+@implementation MPKitButton (ButtonTests)
+@dynamic mParticleInstance;
+@end

--- a/mParticle-ButtonTests/Helpers/mParticle-ButtonTests-Bridging-Header.h
+++ b/mParticle-ButtonTests/Helpers/mParticle-ButtonTests-Bridging-Header.h
@@ -1,0 +1,1 @@
+#import "MPKitButton+ButtonTests.h"

--- a/mParticle-ButtonTests/Info.plist
+++ b/mParticle-ButtonTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/mParticle-ButtonTests/mParticle-ButtonTests.swift
+++ b/mParticle-ButtonTests/mParticle-ButtonTests.swift
@@ -112,8 +112,8 @@ class mParticle_ButtonTests: XCTestCase {
 
         // Assert
         testKitApi.onAttributionCompleteTestHandler = { result, error in
-            let actualURL = result?.linkInfo[BTNPostInstallURLKey] as? URL
-            XCTAssertEqual(actualURL?.absoluteString, url.absoluteString)
+            let actualURL = result?.linkInfo[BTNPostInstallURLKey] as? String
+            XCTAssertEqual(actualURL, url.absoluteString)
             XCTAssertNotNil(url)
             XCTAssertNil(error)
             expectation.fulfill()

--- a/mParticle-ButtonTests/mParticle-ButtonTests.swift
+++ b/mParticle-ButtonTests/mParticle-ButtonTests.swift
@@ -57,7 +57,7 @@ class mParticle_ButtonTests: XCTestCase {
         buttonKit.mParticleInstance = testMParticleInstance
         let configuration = ["application_id": applicationId]
         buttonKit.didFinishLaunching(withConfiguration: configuration)
-        buttonInstance = buttonKit.providerKitInstance as! MPIButton
+        buttonInstance = buttonKit.providerKitInstance as? MPIButton
     }
 
     func testKitCode() {

--- a/mParticle-ButtonTests/mParticle-ButtonTests.swift
+++ b/mParticle-ButtonTests/mParticle-ButtonTests.swift
@@ -1,0 +1,174 @@
+import XCTest
+import ButtonMerchant
+import mParticle_Button
+
+class Actual {
+    static var applicationId: String?
+}
+
+class Stub {
+    static var url: URL?
+    static var error: NSError?
+}
+
+extension ButtonMerchant {
+    @objc public static func configure(applicationId: String) {
+        Actual.applicationId = applicationId
+    }
+    @objc public static func handlePostInstallURL(_ completion: @escaping (URL?, Error?) -> Void) {
+        completion(Stub.url, Stub.error)
+    }
+}
+
+class TestMPKitAPI: MPKitAPI {
+    var onAttributionCompleteTestHandler: ((MPAttributionResult?, NSError?) -> ())!
+    open override func onAttributionComplete(with result: MPAttributionResult?, error: Error?) {
+        onAttributionCompleteTestHandler(result, error as NSError?)
+    }
+}
+
+
+class mParticle_ButtonTests: XCTestCase {
+
+    var buttonKit = MPKitButton()
+    var buttonInstance: MPIButton!
+    var applicationId: String = "app-\(arc4random_uniform(10000))"
+
+    override func setUp() {
+        super.setUp()
+        // Reset all static test output & stubs.
+        Actual.applicationId = nil
+        Stub.url = nil
+        Stub.error = nil
+
+        // Start the Button kit.
+        let configuration = ["application_id": applicationId]
+        buttonKit.didFinishLaunching(withConfiguration: configuration)
+        buttonInstance = buttonKit.providerKitInstance as! MPIButton
+    }
+
+    func testDidFinishLaunchingWithConfiguration() {
+        XCTAssertEqual(Actual.applicationId, applicationId)
+    }
+
+    func testOpenURLOptionsTracks() {
+
+        // Arrange
+        let attributionToken = "testtoken-\(arc4random_uniform(10000))"
+        let url = URL(string: "https://usebutton.com?btn_ref=\(attributionToken)")!
+
+        // Act
+        buttonKit.open(url, options: nil)
+
+        // Assert
+        XCTAssertEqual(ButtonMerchant.attributionToken, attributionToken)
+        XCTAssertEqual(buttonInstance.attributionToken, attributionToken)
+    }
+
+    func testOpenURLSourceApplicationAnnotationTracks() {
+
+        // Arrange
+        let attributionToken = "testtoken-\(arc4random_uniform(10000))"
+        let url = URL(string: "https://usebutton.com?btn_ref=\(attributionToken)")!
+
+        // Act
+        buttonKit.open(url, sourceApplication: "test", annotation: nil)
+
+        // Assert
+        XCTAssertEqual(ButtonMerchant.attributionToken, attributionToken)
+        XCTAssertEqual(buttonInstance.attributionToken, attributionToken)
+    }
+
+    func testContinueUserActivityTracks() {
+
+        // Arrange
+        let attributionToken = "testtoken-\(arc4random_uniform(10000))"
+        let url = URL(string: "https://usebutton.com?btn_ref=\(attributionToken)")!
+        let userActivity = NSUserActivity(activityType: "web")
+        userActivity.webpageURL = url
+
+        // Act
+        buttonKit.continue(userActivity) { handler in }
+
+        // Assert
+        XCTAssertEqual(ButtonMerchant.attributionToken, attributionToken)
+        XCTAssertEqual(buttonInstance.attributionToken, attributionToken)
+    }
+
+    func testPostInstallCheckOnAttribution() {
+
+        // Arrange
+        buttonKit = MPKitButton()
+        let expectation = self.expectation(description: "post-install-url-check")
+        let configuration = ["application_id": applicationId]
+        let attributionToken = "testtoken-\(arc4random_uniform(10000))"
+        let url = URL(string: "https://usebutton.com?btn_ref=\(attributionToken)")!
+        let testKitApi = TestMPKitAPI()
+        buttonKit.kitApi = testKitApi
+        Stub.url = url
+
+        // Act
+        buttonKit.didFinishLaunching(withConfiguration: configuration)
+
+        // Assert
+        testKitApi.onAttributionCompleteTestHandler = { result, error in
+            let actualURL = result?.linkInfo[BTNPostInstallURLKey] as? URL
+            XCTAssertEqual(actualURL?.absoluteString, url.absoluteString)
+            XCTAssertNotNil(url)
+            XCTAssertNil(error)
+            expectation.fulfill()
+        }
+
+        self.wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testPostInstallCheckOnNoAttribution() {
+
+        // Arrange
+        buttonKit = MPKitButton()
+        let expectation = self.expectation(description: "post-install-url-check")
+        let configuration = ["application_id": applicationId]
+        let testKitApi = TestMPKitAPI()
+        buttonKit.kitApi = testKitApi
+        Stub.error = NSError(domain: "test", code: -1, userInfo: nil)
+
+        // Act
+        buttonKit.didFinishLaunching(withConfiguration: configuration)
+
+        // Assert
+        testKitApi.onAttributionCompleteTestHandler = { result, error in
+            let message = error?.userInfo[MPKitButtonErrorMessageKey] as? String
+            XCTAssertEqual(message, "No attribution information available.")
+            XCTAssertNotNil(error)
+            XCTAssertNil(result)
+            expectation.fulfill()
+        }
+
+        self.wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testPostInstallCheckOnError() {
+
+        // Arrange
+        buttonKit = MPKitButton()
+        let expectation = self.expectation(description: "post-install-url-check")
+        let configuration = ["application_id": applicationId]
+        let testKitApi = TestMPKitAPI()
+        buttonKit.kitApi = testKitApi
+        Stub.url = nil
+
+        // Act
+        buttonKit.didFinishLaunching(withConfiguration: configuration)
+
+        // Assert
+        testKitApi.onAttributionCompleteTestHandler = { result, error in
+            let message = error?.userInfo[MPKitButtonErrorMessageKey] as? String
+            XCTAssertEqual(message, "No attribution information available.")
+            XCTAssertNotNil(error)
+            XCTAssertNil(result)
+            expectation.fulfill()
+        }
+
+        self.wait(for: [expectation], timeout: 1.0)
+    }
+}

--- a/mParticle-ButtonTests/mParticle-ButtonTests.swift
+++ b/mParticle-ButtonTests/mParticle-ButtonTests.swift
@@ -20,6 +20,16 @@ extension ButtonMerchant {
     }
 }
 
+class TestMParticle: MParticle {
+    var actualIntegrationAttributes: [String : String]!
+    var actualKitCode: NSNumber!
+    override func setIntegrationAttributes(_ attributes: [String : String], forKit kitCode: NSNumber) -> MPKitExecStatus {
+        actualIntegrationAttributes = attributes
+        actualKitCode = kitCode
+        return MPKitExecStatus()
+    }
+}
+
 class TestMPKitAPI: MPKitAPI {
     var onAttributionCompleteTestHandler: ((MPAttributionResult?, NSError?) -> ())!
     open override func onAttributionComplete(with result: MPAttributionResult?, error: Error?) {
@@ -27,10 +37,10 @@ class TestMPKitAPI: MPKitAPI {
     }
 }
 
-
 class mParticle_ButtonTests: XCTestCase {
 
-    var buttonKit = MPKitButton()
+    var testMParticleInstance: TestMParticle!
+    var buttonKit: MPKitButton!
     var buttonInstance: MPIButton!
     var applicationId: String = "app-\(arc4random_uniform(10000))"
 
@@ -42,9 +52,16 @@ class mParticle_ButtonTests: XCTestCase {
         Stub.error = nil
 
         // Start the Button kit.
+        buttonKit = MPKitButton()
+        testMParticleInstance = TestMParticle()
+        buttonKit.mParticleInstance = testMParticleInstance
         let configuration = ["application_id": applicationId]
         buttonKit.didFinishLaunching(withConfiguration: configuration)
         buttonInstance = buttonKit.providerKitInstance as! MPIButton
+    }
+
+    func testKitCode() {
+        XCTAssertEqual(MPKitButton.kitCode(), 1022)
     }
 
     func testDidFinishLaunchingWithConfiguration() {
@@ -63,6 +80,7 @@ class mParticle_ButtonTests: XCTestCase {
         // Assert
         XCTAssertEqual(ButtonMerchant.attributionToken, attributionToken)
         XCTAssertEqual(buttonInstance.attributionToken, attributionToken)
+        XCTAssertEqual(testMParticleInstance.actualIntegrationAttributes, [ "com.usebutton.source_token": attributionToken ])
     }
 
     func testOpenURLSourceApplicationAnnotationTracks() {
@@ -77,6 +95,7 @@ class mParticle_ButtonTests: XCTestCase {
         // Assert
         XCTAssertEqual(ButtonMerchant.attributionToken, attributionToken)
         XCTAssertEqual(buttonInstance.attributionToken, attributionToken)
+        XCTAssertEqual(testMParticleInstance.actualIntegrationAttributes, [ "com.usebutton.source_token": attributionToken ])
     }
 
     func testContinueUserActivityTracks() {
@@ -93,6 +112,7 @@ class mParticle_ButtonTests: XCTestCase {
         // Assert
         XCTAssertEqual(ButtonMerchant.attributionToken, attributionToken)
         XCTAssertEqual(buttonInstance.attributionToken, attributionToken)
+        XCTAssertEqual(testMParticleInstance.actualIntegrationAttributes, [ "com.usebutton.source_token": attributionToken ])
     }
 
     func testPostInstallCheckOnAttribution() {


### PR DESCRIPTION
### Overview

This change set migrates the implementation of the mParticle Button iOS integration to the open source [Button Merchant Library](https://github.com/button/button-merchant-ios).

### Proposed Changes

- Replaces custom kit implementation with Merchant Library dependency
- Updates unit test coverage and runs CI on the public [Button fork](https://github.com/button/mparticle-apple-integration-button-forked)