### PR TITLE
Change kit deployment target to iOS 9

### DIFF
--- a/mParticle-Button.podspec
+++ b/mParticle-Button.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
     s.source           = { :git => "https://github.com/mparticle-integrations/mparticle-apple-integration-button.git", :tag => s.version.to_s }
     s.social_media_url = "https://twitter.com/mparticles"
 
-    s.ios.deployment_target = "8.0"
+    s.ios.deployment_target = "9.0"
     s.ios.source_files      = 'mParticle-Button/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 7.5.0'
 end


### PR DESCRIPTION
Button Merchant Library supports a minimum of iOS 9.0. 