### PR TITLE
Button ML v1.3.0 sync

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -19,13 +19,13 @@ jobs:
           ${{ runner.os }}-carthage-
 
     - name: Carthage
-      run: carthage update
+      run: ./carthage.sh update
     
     - name: Test
       run: |
         xcodebuild \
           -project mParticle-Button.xcodeproj \
           -scheme mParticle-Button \
-          -destination "platform=iOS Simulator,name=iPhone 11,OS=latest" \
+          -destination "platform=iOS Simulator,name=iPhone 12,OS=latest" \
           clean test
   

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -1,0 +1,31 @@
+name: Run tests
+
+on: pull_request
+
+jobs:
+  build:
+
+    runs-on:  macos-latest
+    
+    steps:
+    - name: Clone Repo
+      uses: actions/checkout@v1
+
+    - uses: actions/cache@v2
+      with:
+        path: Carthage
+        key: ${{ runner.os }}-carthage-${{ hashFiles('**/Cartfile.resolved') }}
+        restore-keys: |
+          ${{ runner.os }}-carthage-
+
+    - name: Carthage
+      run: carthage update
+    
+    - name: Test
+      run: |
+        xcodebuild \
+          -project mParticle-Button.xcodeproj \
+          -scheme mParticle-Button \
+          -destination "platform=iOS Simulator,name=iPhone 11,OS=latest" \
+          clean test
+  

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "button/button-merchant-ios" "1.3.0"
-github "mparticle/mparticle-apple-sdk" "8.0.0-beta1"
+github "mparticle/mparticle-apple-sdk" "7.16.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "button/button-merchant-ios" "1.0.1"
-github "mparticle/mparticle-apple-sdk" "7.10.0"
+github "button/button-merchant-ios" "1.3.0"
+github "mparticle/mparticle-apple-sdk" "7.16.2"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "button/button-merchant-ios" "1.3.0"
-github "mparticle/mparticle-apple-sdk" "7.16.2"
+github "button/button-merchant-ios" "1.4.2"
+github "mparticle/mparticle-apple-sdk" "8.3.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "button/button-merchant-ios" "1.3.0"
-github "mparticle/mparticle-apple-sdk" "7.16.2"
+github "mparticle/mparticle-apple-sdk" "8.0.0-beta1"

--- a/carthage.sh
+++ b/carthage.sh
@@ -1,0 +1,19 @@
+# carthage.sh
+# Usage example: ./carthage.sh build --platform iOS
+
+set -euo pipefail
+
+xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
+trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
+
+# For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
+# the build will fail on lipo due to duplicate architectures.
+
+CURRENT_XCODE_VERSION=$(xcodebuild -version | grep "Build version" | cut -d' ' -f3)
+echo "EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$CURRENT_XCODE_VERSION = arm64 arm64e armv7 armv7s armv6 armv8" >> $xcconfig
+
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$(XCODE_PRODUCT_BUILD_VERSION))' >> $xcconfig
+echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
+
+export XCODE_XCCONFIG_FILE="$xcconfig"
+carthage "$@"

--- a/mParticle-Button.xcodeproj/project.pbxproj
+++ b/mParticle-Button.xcodeproj/project.pbxproj
@@ -181,7 +181,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0940;
-				LastUpgradeCheck = 1010;
+				LastUpgradeCheck = 1240;
 				ORGANIZATIONNAME = mParticle;
 				TargetAttributes = {
 					DB0773D51DB916610031F3E3 = {
@@ -203,6 +203,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = DB0773CC1DB916610031F3E3;
@@ -248,7 +249,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#/usr/local/bin/carthage copy-frameworks";
+			shellScript = "#/usr/local/bin/carthage copy-frameworks\n";
 		};
 		DE81192B214C4E9F00AAC951 /* Carthage */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -264,7 +265,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/mParticle-Button.xcodeproj/xcshareddata/xcschemes/mParticle-Button.xcscheme
+++ b/mParticle-Button.xcodeproj/xcshareddata/xcschemes/mParticle-Button.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/mParticle-Button.xcodeproj/xcshareddata/xcschemes/mParticle-Button.xcscheme
+++ b/mParticle-Button.xcodeproj/xcshareddata/xcschemes/mParticle-Button.xcscheme
@@ -41,6 +41,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DB0773D51DB916610031F3E3"
+            BuildableName = "mParticle_Button.framework"
+            BlueprintName = "mParticle-Button"
+            ReferencedContainer = "container:mParticle-Button.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -53,17 +62,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DB0773D51DB916610031F3E3"
-            BuildableName = "mParticle_Button.framework"
-            BlueprintName = "mParticle-Button"
-            ReferencedContainer = "container:mParticle-Button.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -84,8 +82,6 @@
             ReferencedContainer = "container:mParticle-Button.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/mParticle-Button.xcodeproj/xcshareddata/xcschemes/mParticle-ButtonTests.xcscheme
+++ b/mParticle-Button.xcodeproj/xcshareddata/xcschemes/mParticle-ButtonTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DE81191F214C4CF900AAC951"
+            BuildableName = "mParticle-ButtonTests.xctest"
+            BlueprintName = "mParticle-ButtonTests"
+            ReferencedContainer = "container:mParticle-Button.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "DE81191F214C4CF900AAC951"
-            BuildableName = "mParticle-ButtonTests.xctest"
-            BlueprintName = "mParticle-ButtonTests"
-            ReferencedContainer = "container:mParticle-Button.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:mParticle-Button.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/mParticle-Button/MPKitButton.m
+++ b/mParticle-Button/MPKitButton.m
@@ -159,6 +159,12 @@ NSString * const MPKitButtonIntegrationAttribution = @"com.usebutton.source_toke
                                          returnCode:MPKitReturnCodeSuccess];
 }
 
+- (nonnull MPKitExecStatus *)logout {
+    [ButtonMerchant clearAllData];
+    return [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode]
+                                         returnCode:MPKitReturnCodeSuccess];
+}
+
 
 #pragma mark - Private Methods
 

--- a/mParticle-Button/MPKitButton.m
+++ b/mParticle-Button/MPKitButton.m
@@ -47,6 +47,7 @@ NSString * const MPKitButtonIntegrationAttribution = @"com.usebutton.source_toke
     return ButtonMerchant.attributionToken;
 }
 
+
 @end
 
 
@@ -159,7 +160,8 @@ NSString * const MPKitButtonIntegrationAttribution = @"com.usebutton.source_toke
                                          returnCode:MPKitReturnCodeSuccess];
 }
 
-- (nonnull MPKitExecStatus *)logout {
+
+- (nonnull MPKitExecStatus *)onLogoutComplete:(nonnull FilteredMParticleUser *)user request:(nonnull FilteredMPIdentityApiRequest *)request {
     [ButtonMerchant clearAllData];
     return [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode]
                                          returnCode:MPKitReturnCodeSuccess];

--- a/mParticle-Button/MPKitButton.m
+++ b/mParticle-Button/MPKitButton.m
@@ -161,13 +161,6 @@ NSString * const MPKitButtonIntegrationAttribution = @"com.usebutton.source_toke
 }
 
 
-- (nonnull MPKitExecStatus *)onLogoutComplete:(nonnull FilteredMParticleUser *)user request:(nonnull FilteredMPIdentityApiRequest *)request {
-    [ButtonMerchant clearAllData];
-    return [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode]
-                                         returnCode:MPKitReturnCodeSuccess];
-}
-
-
 - (nonnull MPKitExecStatus *)logBaseEvent:(nonnull MPCommerceEvent *)event {
     if (![event isKindOfClass:[MPCommerceEvent class]] || !event.products) {
         return [[MPKitExecStatus alloc] initWithSDKCode:[[self class] kitCode]

--- a/mParticle-ButtonTests/Helpers/MPKitButton+ButtonTests.h
+++ b/mParticle-ButtonTests/Helpers/MPKitButton+ButtonTests.h
@@ -2,6 +2,7 @@
 
 @interface MPKitButton (ButtonTests)
 @property (nonatomic, strong) MParticle *mParticleInstance;
+@property (nonatomic, strong) NSNotificationCenter *defaultCenter;
 @end
 
 

--- a/mParticle-ButtonTests/Helpers/MPKitButton+ButtonTests.m
+++ b/mParticle-ButtonTests/Helpers/MPKitButton+ButtonTests.m
@@ -2,4 +2,5 @@
 
 @implementation MPKitButton (ButtonTests)
 @dynamic mParticleInstance;
+@dynamic defaultCenter;
 @end

--- a/mParticle-ButtonTests/mParticle-ButtonTests.swift
+++ b/mParticle-ButtonTests/mParticle-ButtonTests.swift
@@ -4,7 +4,6 @@ import mParticle_Button
 
 class Actual {
     static var applicationId: String?
-    static var didCallClearAllData = false
     static var activity: TestActivity!
 }
 
@@ -19,9 +18,6 @@ extension ButtonMerchant {
     }
     @objc public static func handlePostInstallURL(_ completion: @escaping (URL?, Error?) -> Void) {
         completion(Stub.url, Stub.error)
-    }
-    @objc public static func clearAllData() {
-        Actual.didCallClearAllData = true
     }
     static var activity: Activity {
         return Actual.activity
@@ -95,7 +91,6 @@ class mParticle_ButtonTests: XCTestCase {
         super.setUp()
         // Reset all static test output & stubs.
         Actual.applicationId = nil
-        Actual.didCallClearAllData = false
         Actual.activity = TestActivity()
         Stub.url = nil
         Stub.error = nil
@@ -330,16 +325,5 @@ class mParticle_ButtonTests: XCTestCase {
         XCTAssertEqual(Actual.activity.actualProducts?.first?.quantity, 2)
         XCTAssertEqual(Actual.activity.actualProducts?.first?.value, 199)
         XCTAssertNotNil(Actual.activity.actualProducts?[1])
-    }
-    
-    func testLogoutClearsAllData() {
-        // Arrange
-        buttonKit = MPKitButton()
-        
-        // Act
-        buttonKit.onLogoutComplete(FilteredMParticleUser(), request: FilteredMPIdentityApiRequest())
-        
-        // Assert
-        XCTAssertTrue(Actual.didCallClearAllData)
     }
 }

--- a/mParticle-ButtonTests/mParticle-ButtonTests.swift
+++ b/mParticle-ButtonTests/mParticle-ButtonTests.swift
@@ -4,6 +4,7 @@ import mParticle_Button
 
 class Actual {
     static var applicationId: String?
+    static var didCallClearAllData = false
 }
 
 class Stub {
@@ -17,6 +18,9 @@ extension ButtonMerchant {
     }
     @objc public static func handlePostInstallURL(_ completion: @escaping (URL?, Error?) -> Void) {
         completion(Stub.url, Stub.error)
+    }
+    @objc public static func clearAllData() {
+        Actual.didCallClearAllData = true
     }
 }
 
@@ -231,5 +235,16 @@ class mParticle_ButtonTests: XCTestCase {
                                         userInfo: [Notification.Key.NewToken: attributionToken])
         // Assert
         XCTAssertEqual(testMParticleInstance.actualIntegrationAttributes, [ "com.usebutton.source_token": attributionToken ])
+    }
+    
+    func testLogoutClearsAllData() {
+        // Arrange
+        buttonKit = MPKitButton()
+        
+        // Act
+        buttonKit.logout()
+        
+        // Assert
+        XCTAssertTrue(Actual.didCallClearAllData)
     }
 }

--- a/mParticle-ButtonTests/mParticle-ButtonTests.swift
+++ b/mParticle-ButtonTests/mParticle-ButtonTests.swift
@@ -337,7 +337,7 @@ class mParticle_ButtonTests: XCTestCase {
         buttonKit = MPKitButton()
         
         // Act
-        buttonKit.logout()
+        buttonKit.onLogoutComplete(FilteredMParticleUser(), request: FilteredMPIdentityApiRequest())
         
         // Assert
         XCTAssertTrue(Actual.didCallClearAllData)


### PR DESCRIPTION
## Overview

### Attribution change notifications

Whenever a user is deeplinked into the app and a Button source token is detected in the URL, we now update the mParticle integration attributes with that new token.

### Clearing Kit data

This PR allows an mParticle Kit Consumer to clear all Merchant Library data by calling mParticle's reset() method.

### Reporting commerce activity

This PR hooks the ButtonKit into the `logBaseEvent` method to listen to commerce events. For the following supported event names, the respective ML activity method is called:

view_detail -> `ButtonMerchant.activity.productViewed(~)`
add_to_cart -> `ButtonMerchant.activity.productAddedToCart(~)`
checkout -> `ButtonMerchant.activity.cartViewed(~)`
It is important to note that these mappings are best-effort, since the consumer of the ButtonKit (an mParticle Partner) may design their system another way.

Additionally, tries to parse as much info from the mParticle Product into a ButtonProductCompatible which is used by the ML for activity reporting.