### PR TITLE
Fix static library module imports

### DIFF
--- a/mParticle-Button/mParticle_Button.h
+++ b/mParticle-Button/mParticle_Button.h
@@ -9,4 +9,8 @@ FOUNDATION_EXPORT const unsigned char mParticle_ButtonVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <mParticle_Button/PublicHeader.h>
 
+#if defined(__has_include) && __has_include(<mParticle_Button/MPKitButton.h>)
 #import <mParticle_Button/MPKitButton.h>
+#else
+#import "MPKitButton.h"
+#endif


### PR DESCRIPTION
Fixing the case where mParticle_Button is pulled in via Cocoapods as a static library w/ `use_modular_headers!` set.